### PR TITLE
PR#1 Fix: validate task status on creation

### DIFF
--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -3,6 +3,9 @@ from datetime import datetime
 from uuid import uuid4
 
 
+VALID_STATUSES = {"open", "closed", "in_progress"}
+
+
 @dataclass
 class Task:
     title: str
@@ -11,11 +14,20 @@ class Task:
     created_at: datetime = field(default_factory=datetime.now)
     task_id: str = field(default_factory=lambda: uuid4().hex[:8])
 
+    def __post_init__(self):
+        if self.status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{self.status}'. Must be one of: {VALID_STATUSES}"
+            )
+
     def close(self):
         self.status = "closed"
 
     def reopen(self):
         self.status = "open"
+
+    def start(self):
+        self.status = "in_progress"
 
     def __str__(self):
         return f"[{self.status.upper()}] {self.title}"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -18,3 +18,15 @@ def test_reopen_task():
     t.close()
     t.reopen()
     assert t.status == "open"
+
+
+def test_invalid_status_raises():
+    import pytest
+    with pytest.raises(ValueError, match="Invalid status"):
+        Task(title="Bad", status="unknown")
+
+
+def test_start_task():
+    t = Task(title="Work item")
+    t.start()
+    assert t.status == "in_progress"


### PR DESCRIPTION
## Summary
- Adds status validation to `Task.__post_init__`
- Introduces `VALID_STATUSES` constant and `Task.start()` method
- Adds tests for invalid status and status transitions

## Test plan
- `test_invalid_status_raises` passes
- `test_start_task` passes
- Existing tests still pass