### PR TITLE
PR#2 Feature: add flexible task filtering to Project

### DIFF
--- a/tasklib/project.py
+++ b/tasklib/project.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import Callable, List, Optional
 
 from tasklib.task import Task
 
@@ -14,11 +14,24 @@ class Project:
     def add_task(self, task: Task):
         self.tasks.append(task)
 
+    def filter_tasks(
+        self,
+        status: Optional[str] = None,
+        predicate: Optional[Callable[[Task], bool]] = None,
+    ) -> list[Task]:
+        """Filter tasks by status and/or custom predicate."""
+        results = self.tasks
+        if status is not None:
+            results = [t for t in results if t.status == status]
+        if predicate is not None:
+            results = [t for t in results if predicate(t)]
+        return results
+
     def get_open_tasks(self):
-        return [t for t in self.tasks if t.status == "open"]
+        return self.filter_tasks(status="open")
 
     def get_closed_tasks(self):
-        return [t for t in self.tasks if t.status == "closed"]
+        return self.filter_tasks(status="closed")
 
     def __str__(self):
         return f"Project({self.name}, {len(self.tasks)} tasks)"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,3 +23,23 @@ def test_get_open_tasks():
     p.add_task(t2)
     assert len(p.get_open_tasks()) == 1
     assert len(p.get_closed_tasks()) == 1
+
+
+def test_filter_tasks_by_status():
+    p = Project(name="Demo")
+    p.add_task(Task(title="A"))
+    p.add_task(Task(title="B"))
+    t3 = Task(title="C")
+    t3.close()
+    p.add_task(t3)
+    assert len(p.filter_tasks(status="open")) == 2
+    assert len(p.filter_tasks(status="closed")) == 1
+
+
+def test_filter_tasks_by_predicate():
+    p = Project(name="Demo")
+    p.add_task(Task(title="Important bug"))
+    p.add_task(Task(title="Minor tweak"))
+    result = p.filter_tasks(predicate=lambda t: "bug" in t.title.lower())
+    assert len(result) == 1
+    assert result[0].title == "Important bug"


### PR DESCRIPTION
## Summary
- Adds `Project.filter_tasks(status=..., predicate=...)` method
- Refactors `get_open_tasks`/`get_closed_tasks` to use `filter_tasks` internally
- Adds tests for filtering by status and by predicate

## Test plan
- `test_filter_tasks_by_status` passes
- `test_filter_tasks_by_predicate` passes