### PR TITLE
Prepare release v1.1.1

### DIFF
--- a/tasklib/project.py
+++ b/tasklib/project.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import Callable, List, Optional
 
 from tasklib.task import Task
 
@@ -14,11 +14,24 @@ class Project:
     def add_task(self, task: Task):
         self.tasks.append(task)
 
+    def filter_tasks(
+        self,
+        status: Optional[str] = None,
+        predicate: Optional[Callable[[Task], bool]] = None,
+    ) -> list[Task]:
+        """Filter tasks by status and/or custom predicate."""
+        results = self.tasks
+        if status is not None:
+            results = [t for t in results if t.status == status]
+        if predicate is not None:
+            results = [t for t in results if predicate(t)]
+        return results
+
     def get_open_tasks(self):
-        return [t for t in self.tasks if t.status == "open"]
+        return self.filter_tasks(status="open")
 
     def get_closed_tasks(self):
-        return [t for t in self.tasks if t.status == "closed"]
+        return self.filter_tasks(status="closed")
 
     def __str__(self):
         return f"Project({self.name}, {len(self.tasks)} tasks)"

--- a/tasklib/project.py
+++ b/tasklib/project.py
@@ -11,6 +11,11 @@ class Project:
     name: str
     tasks: list[Task] = field(default_factory=list)
 
+    def __post_init__(self):
+        if not self.name or not self.name.strip():
+            raise ValueError("Project name cannot be empty")
+        self.name = self.name.strip()
+
     def add_task(self, task: Task):
         self.tasks.append(task)
 
@@ -33,5 +38,10 @@ class Project:
     def get_closed_tasks(self):
         return self.filter_tasks(status="closed")
 
+    def summary(self) -> str:
+        """Return a summary including open task count."""
+        open_count = len(self.filter_tasks(status="open"))
+        return f"Project({self.name}, {open_count} open / {len(self.tasks)} total)"
+
     def __str__(self):
-        return f"Project({self.name}, {len(self.tasks)} tasks)"
+        return self.summary()

--- a/tasklib/task.py
+++ b/tasklib/task.py
@@ -3,6 +3,9 @@ from datetime import datetime
 from uuid import uuid4
 
 
+VALID_STATUSES = {"open", "closed", "in_progress"}
+
+
 @dataclass
 class Task:
     title: str
@@ -11,11 +14,20 @@ class Task:
     created_at: datetime = field(default_factory=datetime.now)
     task_id: str = field(default_factory=lambda: uuid4().hex[:8])
 
+    def __post_init__(self):
+        if self.status not in VALID_STATUSES:
+            raise ValueError(
+                f"Invalid status '{self.status}'. Must be one of: {VALID_STATUSES}"
+            )
+
     def close(self):
         self.status = "closed"
 
     def reopen(self):
         self.status = "open"
+
+    def start(self):
+        self.status = "in_progress"
 
     def __str__(self):
         return f"[{self.status.upper()}] {self.title}"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -43,3 +43,30 @@ def test_filter_tasks_by_predicate():
     result = p.filter_tasks(predicate=lambda t: "bug" in t.title.lower())
     assert len(result) == 1
     assert result[0].title == "Important bug"
+
+
+def test_empty_project_name_raises():
+    import pytest
+    with pytest.raises(ValueError, match="cannot be empty"):
+        Project(name="")
+
+
+def test_whitespace_project_name_raises():
+    import pytest
+    with pytest.raises(ValueError, match="cannot be empty"):
+        Project(name="   ")
+
+
+def test_project_name_stripped():
+    p = Project(name="  My Project  ")
+    assert p.name == "My Project"
+
+
+def test_summary():
+    p = Project(name="Demo")
+    p.add_task(Task(title="Open task"))
+    t2 = Task(title="Done task")
+    t2.close()
+    p.add_task(t2)
+    assert p.summary() == "Project(Demo, 1 open / 2 total)"
+    assert str(p) == p.summary()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -23,3 +23,23 @@ def test_get_open_tasks():
     p.add_task(t2)
     assert len(p.get_open_tasks()) == 1
     assert len(p.get_closed_tasks()) == 1
+
+
+def test_filter_tasks_by_status():
+    p = Project(name="Demo")
+    p.add_task(Task(title="A"))
+    p.add_task(Task(title="B"))
+    t3 = Task(title="C")
+    t3.close()
+    p.add_task(t3)
+    assert len(p.filter_tasks(status="open")) == 2
+    assert len(p.filter_tasks(status="closed")) == 1
+
+
+def test_filter_tasks_by_predicate():
+    p = Project(name="Demo")
+    p.add_task(Task(title="Important bug"))
+    p.add_task(Task(title="Minor tweak"))
+    result = p.filter_tasks(predicate=lambda t: "bug" in t.title.lower())
+    assert len(result) == 1
+    assert result[0].title == "Important bug"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -18,3 +18,15 @@ def test_reopen_task():
     t.close()
     t.reopen()
     assert t.status == "open"
+
+
+def test_invalid_status_raises():
+    import pytest
+    with pytest.raises(ValueError, match="Invalid status"):
+        Task(title="Bad", status="unknown")
+
+
+def test_start_task():
+    t = Task(title="Work item")
+    t.start()
+    assert t.status == "in_progress"


### PR DESCRIPTION
## Summary
- cherry-pick Fix: validate task status on creation (#1)
- cherry-pick Feature: add flexible task filtering to Project (#2)
- cherry-pick Fix: reject empty project names (#3)

All commits cherry-picked cleanly. PR #2 was added to milestone v1.1.1 after approval to satisfy dependencies.

## Testing
- [x] cherry-pick applied cleanly